### PR TITLE
Change gitattributes to be *.cs instead of *.*

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.* text eol=crlf
+*.cs text eol=crlf
 *.sh text eol=lf


### PR DESCRIPTION
Setting it to *.* broke binary files and caused all files to be treated as text.